### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The implementation is based on a small set of libraries. For the optimization pr
 osqp
 numpy
 scipy
-skimage
+scikit-image
 matplotlib
 ```
 


### PR DESCRIPTION
pip recommends installing scikit-image instead of skimage package. skimage cannot be installed with pip/conda. I tested simulation.py with scikit-image. Did you mean scikit-image?